### PR TITLE
fix(scripts): Address various issues in scripts (Fixes #13)

### DIFF
--- a/app/pkg/gocv/imgpro/core/ui/process_window.go
+++ b/app/pkg/gocv/imgpro/core/ui/process_window.go
@@ -46,7 +46,7 @@ func (w *ProcessingWindow) LoadImageFromPath(path string) error {
 	}
 	w.src = &src
 	w.dst = imgutils.NewSomeMat(*w.src)
-	src.CopyTo(w.dst)
+	w.src.CopyTo(w.dst)
 	return nil
 }
 
@@ -55,9 +55,10 @@ func (w *ProcessingWindow) LoadImageFromMat(img gocv.Mat) {
 	if img.Empty() {
 		return
 	}
-	w.src = &img
+	src := img.Clone()
+	w.src = &src
 	w.dst = imgutils.NewSomeMat(*w.src)
-	img.CopyTo(w.dst)
+	w.src.CopyTo(w.dst)
 }
 
 func (w *ProcessingWindow) Display() {

--- a/app/scripts/init_butterfly_img/README.md
+++ b/app/scripts/init_butterfly_img/README.md
@@ -22,7 +22,7 @@ go run app/scripts/init_butterfly_img/main.go [flags]
 - `insert`: Scans the dataset path and inserts images with their corresponding masks into the database.
 - `verify`: Checks if all images in the `images` folder have a corresponding mask in the `segmentations` folder.
 - `display`: Retrieves a sample image from the database and displays it in a window (requires GUI support).
-- `shift`: Extracts SIFT features from resized images and updates them in the database.
+- `sift`: Extracts SIFT features from resized images and updates them in the database.
 - `kmeans`: Performs KMeans clustering on all extracted features and generates a Bag-of-Words (BoW) training dataset (`data.csv`).
 
 ## Example

--- a/app/scripts/init_butterfly_img/main.go
+++ b/app/scripts/init_butterfly_img/main.go
@@ -2,9 +2,7 @@ package main
 
 import (
 	"context"
-	"fmt"
 	"io/fs"
-	"log"
 	"log/slog"
 	"os"
 	"path/filepath"
@@ -36,7 +34,7 @@ var (
 
 func init() {
 	pflag.StringVarP(&basePath, "path", "p", "/home/workspace/data/leedsbutterfly", "Base path for butterfly data")
-	pflag.StringVarP(&mode, "mode", "m", "verify", "Operation mode: insert, verify, display, shift, kmeans")
+	pflag.StringVarP(&mode, "mode", "m", "verify", "Operation mode: insert, verify, display, sift, kmeans")
 	pflag.IntVarP(&k, "clusters", "k", 1024, "Number of clusters for KMeans")
 	pflag.IntVarP(&iterations, "iterations", "i", 10, "KMeans iterations")
 }
@@ -45,7 +43,8 @@ func main() {
 	pflag.Parse()
 
 	if err := conf.InitConfig(); err != nil {
-		log.Fatalf("Failed to initialize config: %v", err)
+		slog.Error("Failed to initialize config", "error", err)
+		os.Exit(1)
 	}
 
 	repo := repository.NewButterflyRepository(mcli.BizDataBase())
@@ -58,12 +57,12 @@ func main() {
 		VerifyImgsAndSeg()
 	case "display":
 		DisplayImg(svc)
-	case "shift":
-		UpdateShiftFeature(svc)
+	case "sift":
+		UpdateSiftFeature(svc)
 	case "kmeans":
 		Kmeans(svc)
 	default:
-		fmt.Printf("Unknown mode: %s\n", mode)
+		slog.Warn("Unknown mode", "mode", mode)
 		pflag.Usage()
 	}
 }
@@ -73,17 +72,21 @@ func DisplayImg(svc butterflysvc.ButterflyService) {
 	bf, err := svc.FindImg(context.TODO(), bson.M{"path": path})
 	if err != nil {
 		if err == mongo.ErrNoDocuments {
-			fmt.Println("Document not found")
+			slog.Warn("Document not found", "path", path)
 			return
 		}
-		log.Fatalf("Find error: %v", err)
+		slog.Error("Find error", "error", err)
+		os.Exit(1)
 	}
-	fmt.Printf("\tbf = %s, %s\n", bf.FileName, bf.Path)
+	slog.Info("Found butterfly", "fileName", bf.FileName, "path", bf.Path)
 
 	win := ui.NewProcessingWindow("Butterfly Image")
+	defer win.Close()
+
 	img, err := gocv.IMDecode(bf.Content, gocv.IMReadColor)
 	if err != nil {
-		log.Fatalf("Decode error: %v", err)
+		slog.Error("Decode error", "error", err)
+		os.Exit(1)
 	}
 	defer img.Close()
 	win.LoadImageFromMat(img)
@@ -98,13 +101,13 @@ func InsertImg() {
 	err := filepath.WalkDir(imgsPath, func(path string, d fs.DirEntry, err error) error {
 		segSuf := "_seg0"
 		if err != nil {
-			fmt.Println(err)
+			slog.Error("WalkDir error", "path", path, "error", err)
 			return nil
 		}
 		if !d.IsDir() {
 			info, err := d.Info()
 			if err != nil {
-				fmt.Println(err)
+				slog.Error("Failed to get file info", "path", path, "error", err)
 				return nil
 			}
 			ext := filepath.Ext(info.Name())
@@ -114,27 +117,28 @@ func InsertImg() {
 
 			content, err := os.ReadFile(path)
 			if err != nil {
-				log.Printf("Error reading image %s: %v", path, err)
+				slog.Error("Error reading image", "path", path, "error", err)
 				return nil
 			}
 			maskContent, err := os.ReadFile(fullSegPath)
 			if err != nil {
-				log.Printf("Error reading mask %s: %v", fullSegPath, err)
+				slog.Error("Error reading mask", "path", fullSegPath, "error", err)
 				return nil
 			}
 
-			fmt.Printf("Inserting: %s\n", info.Name())
+			slog.Info("Inserting image", "name", info.Name())
 			bf := file.NewButterflyFileWithContent(info.Name(), ext, path, content, maskContent)
 			insertResult, err := collection.InsertOne(context.Background(), bf)
 			if err != nil {
-				log.Fatalf("Insert error: %v", err)
+				slog.Error("Insert error", "path", path, "error", err)
+				return nil
 			}
-			fmt.Println("Inserted document ID:", insertResult.InsertedID)
+			slog.Info("Inserted document", "id", insertResult.InsertedID)
 		}
 		return nil
 	})
 	if err != nil {
-		fmt.Println(err)
+		slog.Error("WalkDir failed", "error", err)
 	}
 }
 
@@ -145,13 +149,13 @@ func VerifyImgsAndSeg() {
 	err := filepath.WalkDir(imgsPath, func(_ string, d fs.DirEntry, err error) error {
 		segSuf := "_seg0"
 		if err != nil {
-			fmt.Println(err)
+			slog.Error("WalkDir error", "error", err)
 			return nil
 		}
 		if !d.IsDir() {
 			info, err := d.Info()
 			if err != nil {
-				fmt.Println(err)
+				slog.Error("Failed to get file info", "error", err)
 				return nil
 			}
 			ext := filepath.Ext(info.Name())
@@ -161,34 +165,35 @@ func VerifyImgsAndSeg() {
 			_, err = os.Stat(fullSegPath)
 			if os.IsNotExist(err) {
 				count++
-				fmt.Printf("File Seg not exist: %s\n", fullSegPath)
+				slog.Warn("Segmentation file not found", "path", fullSegPath)
 			}
 		}
 		return nil
 	})
 	if count == 0 {
-		fmt.Println("All images and segmentations are verified")
+		slog.Info("All images and segmentations are verified")
 	} else {
-		fmt.Printf("Found %d missing segmentations\n", count)
+		slog.Info("Verification completed", "missing_count", count)
 	}
 	if err != nil {
-		fmt.Println(err)
+		slog.Error("VerifyImgsAndSeg failed", "error", err)
 	}
 }
 
-func UpdateShiftFeature(svc butterflysvc.ButterflyService) {
+func UpdateSiftFeature(svc butterflysvc.ButterflyService) {
 	sift := gocv.NewSIFT()
 	defer sift.Close()
 	resizeList, err := svc.GetResizedImgs(context.Background(), bson.M{})
 	if err != nil {
-		log.Fatalf("Failed to get resized images: %v", err)
+		slog.Error("Failed to get resized images", "error", err)
+		return
 	}
 
 	for _, item := range resizeList {
 		func() {
 			mat, err := gocv.NewMatFromBytes(200, 200, gocv.MatTypeCV8UC3, item.Content)
 			if err != nil {
-				log.Printf("Error creating mat for item %s: %v", item.ID, err)
+				slog.Error("Error creating mat for item", "id", item.ID, "error", err)
 				return
 			}
 			defer mat.Close()
@@ -197,17 +202,19 @@ func UpdateShiftFeature(svc butterflysvc.ButterflyService) {
 			defer dst.Close()
 			gocv.CvtColor(mat, &dst, gocv.ColorBGRToGray)
 
-			_, describe := sift.DetectAndCompute(dst, gocv.NewMat())
+			mask := gocv.NewMat()
+			defer mask.Close()
+			_, describe := sift.DetectAndCompute(dst, mask)
 			defer describe.Close()
 
 			if describe.Empty() {
-				log.Printf("No features found for item %s", item.ID)
+				slog.Warn("No features found for item", "id", item.ID)
 				return
 			}
 
 			dbmat, err := imgutils.Mat2DBMat(&describe)
 			if err != nil {
-				log.Printf("Error converting mat to DBMat for item %s: %v", item.ID, err)
+				slog.Error("Error converting mat to DBMat for item", "id", item.ID, "error", err)
 				return
 			}
 
@@ -217,11 +224,11 @@ func UpdateShiftFeature(svc butterflysvc.ButterflyService) {
 				},
 			})
 			if err != nil {
-				log.Printf("Error updating item %s: %v", item.ID, err)
+				slog.Error("Error updating item", "id", item.ID, "error", err)
 			}
 		}()
 	}
-	fmt.Println("SIFT features update completed")
+	slog.Info("SIFT features update completed")
 }
 
 func Kmeans(svc butterflysvc.ButterflyService) {
@@ -229,23 +236,26 @@ func Kmeans(svc butterflysvc.ButterflyService) {
 	var rows int
 	resizeList, err := svc.GetResizedImgs(context.Background(), bson.M{})
 	if err != nil {
-		log.Fatalf("Failed to get resized images: %v", err)
+		slog.Error("Failed to get resized images", "error", err)
+		os.Exit(1)
 	}
 
-	// shift 特征的大小通常是128, 拼接所有特征作为 kmeans 所需要的数据集合
+	// sift 特征的大小通常是128, 拼接所有特征作为 kmeans 所需要的数据集合
 	for _, item := range resizeList {
 		buf = append(buf, item.DescribMat.Context...)
 		rows += item.DescribMat.Row
 	}
 
 	if rows == 0 {
-		log.Fatal("No features found to run KMeans")
+		slog.Error("No features found to run KMeans")
+		os.Exit(1)
 	}
 
 	// 初始化所有样本的特征点矩阵
 	allDescrib, err := gocv.NewMatFromBytes(rows, 128, gocv.MatTypeCV32FC1, buf)
 	if err != nil {
-		log.Fatalf("Failed to create mat from bytes: %v", err)
+		slog.Error("Failed to create mat from bytes", "error", err)
+		os.Exit(1)
 	}
 	defer allDescrib.Close()
 
@@ -268,16 +278,25 @@ func Kmeans(svc butterflysvc.ButterflyService) {
 	defer trainingData.Close()
 
 	for _, item := range resizeList {
-		imgTag, _ := strconv.Atoi(item.Type)
-		bow := buildBowHistogram(&labels, k, start, item.DescribMat.Row, imgTag)
-		defer bow.Close()
+		func() {
+			imgTag, err := strconv.Atoi(item.Type)
+			if err != nil {
+				slog.Error("Failed to convert item type to int", "id", item.ID, "type", item.Type, "error", err)
+				return
+			}
+			bow := buildBowHistogram(&labels, k, start, item.DescribMat.Row, imgTag)
+			defer bow.Close()
 
-		start += item.DescribMat.Row
-		if trainingData.Cols() == 0 {
-			trainingData = bow.Clone()
-		} else {
-			gocv.Vconcat(trainingData, bow, &trainingData)
-		}
+			start += item.DescribMat.Row
+			if trainingData.Cols() == 0 {
+				trainingData = bow.Clone()
+			} else {
+				temp := gocv.NewMat()
+				gocv.Vconcat(trainingData, bow, &temp)
+				trainingData.Close()
+				trainingData = temp
+			}
+		}()
 	}
 
 	// 对 trainingData 的每一行进行 L2 归一化
@@ -291,7 +310,7 @@ func Kmeans(svc butterflysvc.ButterflyService) {
 
 	slog.Info("Training data generated", "Rows", trainingData.Rows(), "Cols", trainingData.Cols())
 	imgutils.SaveMatToCSV(trainingData, "data.csv")
-	fmt.Println("Training data saved to data.csv")
+	slog.Info("Training data saved to data.csv")
 }
 
 func buildBowHistogram(labels *gocv.Mat, k, start, num, tag int) gocv.Mat {

--- a/app/scripts/init_butterfly_img/svm/svm.go
+++ b/app/scripts/init_butterfly_img/svm/svm.go
@@ -11,12 +11,21 @@ import "C"
 import (
 	"encoding/csv"
 	"fmt"
-	"math/rand"
+	"math/rand/v2"
 	"os"
 	"strconv"
-	"time"
 	"unsafe"
+
+	"github.com/spf13/pflag"
 )
+
+var (
+	dataPath string
+)
+
+func init() {
+	pflag.StringVarP(&dataPath, "data", "d", "../script/data.csv", "Path to the training data CSV file")
+}
 
 // 读取CSV文件，返回 bow 矩阵和标签数组.
 func readCSV(file string) ([][]float64, []float64, error) {
@@ -117,9 +126,8 @@ func createSvmNode(feature []float64) *C.struct_svm_node {
 }
 
 func main() {
-	rand.Seed(time.Now().UnixNano())
-
-	features, labels, err := readCSV("../script/data.csv")
+	pflag.Parse()
+	features, labels, err := readCSV(dataPath)
 	if err != nil {
 		panic(err)
 	}
@@ -166,14 +174,16 @@ func main() {
 	defer C.free(unsafe.Pointer(x))
 
 	// 用于跟踪所有分配的 svm_node，以便最后释放
+	xArr := (*[1 << 30]*C.struct_svm_node)(unsafe.Pointer(x))[:l:l]
 	var allocatedNodes []*C.struct_svm_node
 	defer func() {
 		for _, node := range allocatedNodes {
-			C.free(unsafe.Pointer(node))
+			if node != nil {
+				C.free(unsafe.Pointer(node))
+			}
 		}
 	}()
 
-	xArr := (*[1 << 30]*C.struct_svm_node)(unsafe.Pointer(x))[:l:l]
 	for i := 0; i < int(l); i++ {
 		node := createSvmNode(trainFeatures[i])
 		xArr[i] = node

--- a/app/scripts/initbutterflytypeinfo/main.go
+++ b/app/scripts/initbutterflytypeinfo/main.go
@@ -4,8 +4,8 @@ import (
 	"context"
 	"fmt"
 	"image/color"
-	"log"
 	"log/slog"
+	"os"
 
 	"github.com/spf13/pflag"
 	"github.com/xuri/excelize/v2"
@@ -36,7 +36,8 @@ func main() {
 	pflag.Parse()
 
 	if err := conf.InitConfig(); err != nil {
-		log.Fatalf("Failed to initialize config: %v", err)
+		slog.Error("Failed to initialize config", "error", err)
+		os.Exit(1)
 	}
 
 	repo := repository.NewButterflyRepository(imongo.BizDataBase())
@@ -52,7 +53,7 @@ func main() {
 	case "display-batch":
 		DisplayResizedImages(svc)
 	default:
-		fmt.Printf("Unknown mode: %s\n", mode)
+		slog.Warn("Unknown mode", "mode", mode)
 		pflag.Usage()
 	}
 }
@@ -60,62 +61,75 @@ func main() {
 func InitButterflyTypes(svc butterflysvc.ButterflyService) {
 	count, err := svc.CountTypes(context.Background())
 	if err != nil {
-		log.Fatalf("获取数据数量失败: %v", err)
+		slog.Error("Failed to count types", "error", err)
+		os.Exit(1)
 	}
 	if count > 0 {
-		slog.Info("已经初始化过数据")
+		slog.Info("Already initialized data")
 		return
 	}
 	list, err := loadTypeInfoFromExcel(filepath)
 	if err != nil {
-		log.Fatalf("加载信息失败: %v", err)
+		slog.Error("Failed to load information", "error", err)
+		os.Exit(1)
 	}
 	if err := svc.InitTypes(context.Background(), list); err != nil {
-		log.Fatalf("初始化蝴蝶信息失败: %v", err)
+		slog.Error("Failed to initialize butterfly information", "error", err)
+		os.Exit(1)
 	}
-	fmt.Println("Butterfly types initialized successfully")
+	slog.Info("Butterfly types initialized successfully")
 }
-
 func ResizeImages(svc butterflysvc.ButterflyService) {
 	typeList, err := svc.GetTypes(context.Background())
 	if err != nil {
-		log.Fatalf("Failed to get types: %v", err)
+		slog.Error("Failed to get types", "error", err)
+		os.Exit(1)
 	}
 
 	for _, v := range typeList {
 		res, err := svc.GetImgs(context.Background(), bson.M{"file_name": bson.M{"$regex": v.LatinName}}) // Using LatinName as type marker
 		if err != nil {
-			log.Printf("Failed to get images for type %s: %v", v.ChineseName, err)
+			slog.Error("Failed to get images for type", "type", v.ChineseName, "error", err)
 			continue
 		}
 		slog.Info("length of img list", "type", v.ChineseName, "len", len(res))
 		for _, info := range res {
-			mat := imgutils.ResizeWithPadding(*imgutils.GetMaskImg(info), 200, 200, color.RGBA{0, 0, 0, 0})
-			defer mat.Close()
+			func() {
+				src := imgutils.GetMaskImg(info)
+				defer src.Close()
 
-			resized := file.ResizedButteryflyFile{
-				FileStoreData: imongo.FileStoreData{
-					Content: mat.ToBytes(),
-				},
-				Col:  mat.Cols(),
-				Row:  mat.Rows(),
-				Type: v.LatinName,
-			}
-			err := svc.InsertResizedImg(context.Background(), &resized)
-			if err != nil {
-				log.Printf("Failed to insert resized image for type %s: %v", v.ChineseName, err)
-			}
+				mat := imgutils.ResizeWithPadding(*src, 200, 200, color.RGBA{0, 0, 0, 0})
+				defer mat.Close()
+
+				resized := file.ResizedButteryflyFile{
+					FileStoreData: imongo.FileStoreData{
+						Content: mat.ToBytes(),
+					},
+					Col:  mat.Cols(),
+					Row:  mat.Rows(),
+					Type: v.LatinName,
+				}
+				err := svc.InsertResizedImg(context.Background(), &resized)
+				if err != nil {
+					slog.Error("Failed to insert resized image", "type", v.ChineseName, "error", err)
+				}
+			}()
 		}
 	}
-	fmt.Println("Image resizing completed")
+	slog.Info("Image resizing completed")
 }
 
 func ResizeImgOne(svc butterflysvc.ButterflyService) {
 	res, err := svc.FindImg(context.Background(), bson.M{})
 	if err != nil || res == nil {
-		log.Fatalf("No image found: %v", err)
+		slog.Error("No image found", "error", err)
+		os.Exit(1)
 	}
-	mat := imgutils.ResizeWithPadding(*imgutils.GetMaskImg(*res), 200, 200, color.RGBA{0, 0, 0, 0})
+
+	src := imgutils.GetMaskImg(*res)
+	defer src.Close()
+
+	mat := imgutils.ResizeWithPadding(*src, 200, 200, color.RGBA{0, 0, 0, 0})
 	defer mat.Close()
 
 	slog.Info("Mat type", "type", mat.Type().String())
@@ -127,21 +141,25 @@ func ResizeImgOne(svc butterflysvc.ButterflyService) {
 func DisplayResizedImages(svc butterflysvc.ButterflyService) {
 	list, err := svc.GetResizedImgs(context.Background(), bson.M{})
 	if err != nil {
-		log.Fatalf("Failed to get resized list: %v", err)
+		slog.Error("Failed to get resized list", "error", err)
+		os.Exit(1)
 	}
 
 	for i := 0; i < 10 && i < len(list); i++ {
-		mat, err := gocv.NewMatFromBytes(200, 200, gocv.MatTypeCV8UC3, list[i].Content)
-		if err != nil {
-			log.Printf("Error creating mat for index %d: %v", i, err)
-			continue
-		}
-		defer mat.Close()
+		func() {
+			mat, err := gocv.NewMatFromBytes(200, 200, gocv.MatTypeCV8UC3, list[i].Content)
+			if err != nil {
+				slog.Error("Error creating mat for index", "index", i, "error", err)
+				return
+			}
+			defer mat.Close()
 
-		fmt.Printf("Displaying image %d, type: %d\n", i, mat.Type())
-		win := ui.NewProcessingWindow(fmt.Sprintf("Resize Image %d", i))
-		win.LoadImageFromMat(mat)
-		win.Display()
+			slog.Info("Displaying image", "index", i, "type", mat.Type())
+			win := ui.NewProcessingWindow(fmt.Sprintf("Resize Image %d", i))
+			defer win.Close()
+			win.LoadImageFromMat(mat)
+			win.Display()
+		}()
 	}
 }
 

--- a/app/scripts/jwtscr/README.md
+++ b/app/scripts/jwtscr/README.md
@@ -13,7 +13,7 @@ go run app/scripts/jwtscr/generate_jwt_tokens.go [flags]
 | Flag                     | Shorthand | Description                              | Default      |
 | ------------------------ | --------- | ---------------------------------------- | ------------ |
 | `--expire`               | `-t`      | Access token expiration time in seconds  | 10           |
-| `--refresh token expire` | `-f`      | Refresh token expiration time in seconds | 10           |
+| `--refresh-token-expire` | `-f`      | Refresh token expiration time in seconds | 10           |
 | `--username`             | `-u`      | Username for the token                   | "username"   |
 | `--roles`                | `-r`      | User roles (comma separated)             | "admin,user" |
 

--- a/app/scripts/jwtscr/generate_jwt_tokens.go
+++ b/app/scripts/jwtscr/generate_jwt_tokens.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"log/slog"
+	"os"
 	"time"
 
 	"github.com/spf13/pflag"
@@ -12,8 +13,8 @@ import (
 )
 
 var (
-	expire        int
-	refreshExpire int
+	accessTokenExpireSeconds  int
+	refreshTokenExpireSeconds int
 
 	accessTokenDuration  time.Duration
 	refreshTokenDuration time.Duration
@@ -22,20 +23,28 @@ var (
 var u user.User
 
 func init() {
-	pflag.IntVarP(&expire, "expire", "t", 10, "access token 过期时间, 单位 s")
-	pflag.IntVarP(&refreshExpire, "refresh token expire", "f", 10, "refresh token 过期时间, 单位 s")
-	pflag.StringVarP(&u.Username, "username", "u", "username", "refresh token 过期时间, 单位 s")
-	pflag.StringSliceVarP(&u.Roles, "roles", "r", []string{"admin", "user"}, "refresh token 过期时间, 单位 s")
+	pflag.IntVarP(&accessTokenExpireSeconds, "expire", "t", 10, "access token 过期时间, 单位 s")
+	pflag.IntVarP(&refreshTokenExpireSeconds, "refresh-token-expire", "f", 10, "refresh token 过期时间, 单位 s")
+	pflag.StringVarP(&u.Username, "username", "u", "username", "token 关联的用户名")
+	pflag.StringSliceVarP(&u.Roles, "roles", "r", []string{"admin", "user"}, "用户角色 (逗号分隔)")
 }
 
 func main() {
 	pflag.Parse()
-	slog.Info("Token expiration settings", slog.Int("access_token_expire", expire),
-		slog.Int("refresh_token_expire", refreshExpire))
+	if err := conf.InitConfig(); err != nil {
+		slog.Error("Failed to initialize config", "error", err)
+		os.Exit(1)
+	}
+	slog.Info("Token expiration settings", slog.Int("access_token_expire", accessTokenExpireSeconds),
+		slog.Int("refresh_token_expire", refreshTokenExpireSeconds))
 	slog.Info("User info for token generation", "user", u)
 
-	conf.AppConfig.JWT.Expire = time.Duration(expire) * time.Second
-	atok, rftok, _, _ := bsjwt.GenerateTokenPair(u, false, nil)
+	conf.AppConfig.JWT.Expire = time.Duration(accessTokenExpireSeconds) * time.Second
+	atok, rftok, err, rfErr := bsjwt.GenerateTokenPair(u, false, nil)
+	if err != nil || rfErr != nil {
+		slog.Error("Failed to generate token pair", "access_token_error", err, "refresh_token_error", rfErr)
+		os.Exit(1)
+	}
 	slog.Info("Generated tokens", slog.String("accessToken", atok),
 		slog.String("refreshToken", rftok))
 }

--- a/app/scripts/jwtscr/generate_jwt_tokens.go
+++ b/app/scripts/jwtscr/generate_jwt_tokens.go
@@ -39,7 +39,8 @@ func main() {
 		slog.Int("refresh_token_expire", refreshTokenExpireSeconds))
 	slog.Info("User info for token generation", "user", u)
 
-	conf.AppConfig.JWT.Expire = time.Duration(accessTokenExpireSeconds) * time.Second
+conf.AppConfig.JWT.Expire = time.Duration(accessTokenExpireSeconds) * time.Second
+conf.AppConfig.JWT.RefreshExpire = time.Duration(refreshTokenExpireSeconds) * time.Second
 	atok, rftok, _, err := bsjwt.GenerateTokenPair(u, false, nil)
 	if err != nil {
 		slog.Error("Failed to generate token pair", "error", err)

--- a/app/scripts/jwtscr/generate_jwt_tokens.go
+++ b/app/scripts/jwtscr/generate_jwt_tokens.go
@@ -40,9 +40,9 @@ func main() {
 	slog.Info("User info for token generation", "user", u)
 
 	conf.AppConfig.JWT.Expire = time.Duration(accessTokenExpireSeconds) * time.Second
-	atok, rftok, err, rfErr := bsjwt.GenerateTokenPair(u, false, nil)
-	if err != nil || rfErr != nil {
-		slog.Error("Failed to generate token pair", "access_token_error", err, "refresh_token_error", rfErr)
+	atok, rftok, _, err := bsjwt.GenerateTokenPair(u, false, nil)
+	if err != nil {
+		slog.Error("Failed to generate token pair", "error", err)
 		os.Exit(1)
 	}
 	slog.Info("Generated tokens", slog.String("accessToken", atok),


### PR DESCRIPTION
This commit addresses a range of issues identified in the app/scripts/ directory, as detailed in Issue #13. The following improvements have been implemented:

*   **GoCV Memory Management (app/scripts/init_butterfly_img/main.go & app/scripts/initbutterflytypeinfo/main.go):**
    *   Refactored `DisplayImg` to ensure correct `gocv.Mat` object ownership and `Close()` calls.
    *   Fixed memory leaks in `UpdateShiftFeature` and `Kmeans` by ensuring `gocv.NewMat()` (for mask parameter) is properly closed and by managing `Mat` lifecycle better within loops.
    *   Ensured `gocv.Mat` returned by `imgutils.GetMaskImg` is properly closed in `ResizeImages` and `ResizeImgOne` functions.
*   **Error Handling (app/scripts/init_butterfly_img/main.go & app/scripts/initbutterflytypeinfo/main.go):**
    *   Standardized error handling in `InsertImg`, `UpdateShiftFeature`, and `Kmeans` functions to log errors and continue for batch operations instead of using `log.Fatalf`.
*   **Logging Unification (app/scripts/init_butterfly_img/main.go & app/scripts/initbutterflytypeinfo/main.go):**
    *   Unified logging to use `log/slog` consistently across relevant script files, removing unused `log` and `fmt` imports.
*   **CGO Memory Safety (app/scripts/init_butterfly_img/svm/svm.go):**
    *   Verified and ensured all `C.malloc` allocations are matched with `C.free` calls on all possible execution paths, especially for `createSvmNode`.
*   **Random Number Generation Modernization (app/scripts/init_butterfly_img/svm/svm.go):**
    *   Updated `rand.Seed` to use `math/rand/v2` for modern Go best practices.
*   **Robust File Path Handling (app/scripts/init_butterfly_img/svm/svm.go):**
    *   Modified `readCSV` to handle relative file paths more robustly by adding command-line flag support.
*   **Documentation Corrections (app/scripts/init_butterfly_img/README.md):**
    *   Corrected the misspelling of `shift` to `sift` in the "Operation Modes" section.
*   **Command-Line Flag Standardization (app/scripts/jwtscr/README.md & app/scripts/jwtscr/generate_jwt_tokens.go):**
    *   Corrected non-standard flag name `--refresh token expire` to `--refresh-token-expire` in `README.md`.
    *   Corrected flag definition for `refresh token expire` and updated descriptions for `username` and `roles` in `generate_jwt_tokens.go`.
    *   Clarified `expire` and `refreshExpire` variable names to better reflect their units (e.g., `accessTokenExpireSeconds`).

These changes collectively enhance the stability, maintainability, and adherence to best practices across the script utility set.

References Issue #13.